### PR TITLE
MQTT requires LB2.0

### DIFF
--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -160,11 +160,20 @@ $template->param( FRITZ_ENABLE => $fritz_enable );
 
 
 # UDP Enabled
-@values = ('0', '1' );
-%labels = (
-      '0' => "mqtt",
-      '1' => "UDP",
-  );
+my $loxberryversion = LoxBerry::System::lbversion();
+
+if($loxberryversion == 2) {
+    @values = ('0', '1' );
+    %labels = (
+          '0' => "mqtt",
+          '1' => "UDP",
+      );
+} else {
+    @values = ('1');
+    %labels = (
+          '1' => "UDP",
+      );
+}
 my $udp_enable = $cgi->popup_menu(
       -name    => 'udp_enable',
       -id      => 'udp_enable',


### PR DESCRIPTION
damit könnte es funktionieren !? Müssten dann evtl nur die beschreibung vom Template ändern.
auf meinem Loxberry 2.0.1.3 kann ich nach wie vor noch auf MQTT stellen. Kannst du es testen ob es bei dir dann auf UDP bleibt?