### PR TITLE
Update check.pl

### DIFF
--- a/bin/check.pl
+++ b/bin/check.pl
@@ -92,6 +92,8 @@ for ($i=1;$i<=$user_count;$i++) {
     $user{NAME} = $pcfg->param("USER$i.NAME");
     LOGDEB "Found config for $user{NAME}";
     my $input = $pcfg->param("USER$i.MACS");
+    # Entferne alle Zeichen außer 0-9, a-z, A-Z, ., -, ; und : aus dem String
+    $input =~ s/[^0-9a-zA-Z\.\-;:]//g;
     my @input_splitted = split /;/, $input;
 
     my @ips = ();


### PR DESCRIPTION

![grafik-1](https://github.com/Gagi2k/LoxBerry-Plugin-WifiScanner/assets/46262695/b7140b7e-07d9-4800-ad58-b0690519902e)

![grafik](https://github.com/Gagi2k/LoxBerry-Plugin-WifiScanner/assets/46262695/3edfcecd-38b7-451d-9078-c463110173ab)

Änderung entfernt unsichtbare Sonderzeichen im Eingabefest für MAC und/oder IP.